### PR TITLE
Update script for ingestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "devDependencies": {
     "@mdn/browser-compat-data": "latest",
+    "btoa": "1.2.1",
     "node-fetch": "^3.2.0"
   }
 }

--- a/update_remote_settings_records.mjs
+++ b/update_remote_settings_records.mjs
@@ -5,17 +5,18 @@
 /* global process */
 
 // This script consumes the following env variables:
-// - AUTHORIZATION (mandatory): Raw authorization header (e.g. `AUTHORIZATION='Bearer XXXXXXXXXXXXX'`)
-// - SERVER (mandatory): Writer server URL (eg. https://settings-writer.stage.mozaws.net/v1)
-// - ENVIRONMENT (optional): dev, stage, prod. When set to `dev`, the script will approve its own changes.
-// - DRY_RUN (optional): If set to 1, no changes will be made to the collection, this will
+// - FX_REMOTE_SETTINGS_WRITER_USER (mandatory): User
+// - FX_REMOTE_SETTINGS_WRITER_PASS (mandatory): Password
+// - FX_REMOTE_SETTINGS_WRITER_SERVER (mandatory): Writer server URL (eg. https://settings-writer.stage.mozaws.net/v1)
+// - FX_REMOTE_SETTINGS_ENVIRONMENT (optional): dev, stage, prod. When set to `dev`, the script will approve its own changes.
+// - FX_REMOTE_SETTINGS_DRY_RUN (optional): If set to 1, no changes will be made to the collection, this will
 //                       only log the actions that would be done.
-
 // This node script fetches `https://github.com/mdn/browser-compat-data/tree/main/browsers`
 // and updates records from the associated collection in RemoteSettings.
 // In the future, it will also handle https://github.com/mdn/browser-compat-data/tree/main/css.
 
 import fetch from "node-fetch";
+import btoa from "btoa";
 
 // Use the legacy wrapper to support all Node 12+ versions.
 // If we only support Node 16+, can be updated to:
@@ -27,34 +28,44 @@ const SUCCESS_RET_VALUE = 0;
 const FAILURE_RET_VALUE = 1;
 const VALID_ENVIRONMENTS = ["dev", "stage", "prod"];
 
-if (!process.env.AUTHORIZATION) {
-  console.error(`AUTHORIZATION environment variable needs to be set`);
+if (
+  !process.env.FX_REMOTE_SETTINGS_WRITER_USER ||
+  !process.env.FX_REMOTE_SETTINGS_WRITER_PASS
+) {
+  console.error(
+    `Both FX_REMOTE_SETTINGS_WRITER_USER and FX_REMOTE_SETTINGS_WRITER_PASS environment variables need to be set`
+  );
   process.exit(FAILURE_RET_VALUE);
 }
 
-if (!process.env.SERVER) {
-  console.error(`SERVER environment variable needs to be set`);
+if (!process.env.FX_REMOTE_SETTINGS_WRITER_SERVER) {
+  console.error(
+    `FX_REMOTE_SETTINGS_WRITER_SERVER environment variable needs to be set`
+  );
   process.exit(FAILURE_RET_VALUE);
 }
 
 if (
-  process.env.ENVIRONMENT &&
+  process.env.FX_REMOTE_SETTINGS_ENVIRONMENT &&
   !VALID_ENVIRONMENTS.includes(process.env.ENVIRONMENT)
 ) {
   console.error(
-    `ENVIRONMENT environment variable needs to be set to one of the following values: ${VALID_ENVIRONMENTS.join(
+    `FX_REMOTE_SETTINGS_ENVIRONMENT environment variable needs to be set to one of the following values: ${VALID_ENVIRONMENTS.join(
       ", "
     )}`
   );
   process.exit(FAILURE_RET_VALUE);
 }
 
-const rsBrowsersCollectionEndpoint = `${process.env.SERVER}/buckets/main-workspace/collections/devtools-compatibility-browsers`;
+const rsBrowsersCollectionEndpoint = `${process.env.FX_REMOTE_SETTINGS_WRITER_SERVER}/buckets/main-workspace/collections/devtools-compatibility-browsers`;
 const rsBrowsersRecordsEndpoint = `${rsBrowsersCollectionEndpoint}/records`;
-const isDryRun = process.env.DRY_RUN == "1";
+const isDryRun = process.env.FX_REMOTE_SETTINGS_DRY_RUN == "1";
+
 const headers = {
   "Content-Type": "application/json",
-  Authorization: process.env.AUTHORIZATION,
+  Authorization: `Basic ${btoa(
+    `${process.env.FX_REMOTE_SETTINGS_WRITER_USER}:${process.env.FX_REMOTE_SETTINGS_WRITER_PASS}`
+  )}`,
 };
 
 update()
@@ -147,7 +158,7 @@ async function update() {
     const refreshedRecords = await getRSRecords();
     console.log("Browsers data synced ✅\nRefreshed records:");
     console.table(refreshedRecords);
-    if (process.env.ENVIRONMENT === "dev") {
+    if (process.env.FX_REMOTE_SETTINGS_ENVIRONMENT === "dev") {
       await approveChanges();
     } else {
       await requestReview();


### PR DESCRIPTION
The script will be run passing it login and password ENV variables,
but the script only takes a simple token at the moment.
This patch changes this so we only take login/password variables,
and we update the ENV variable names to make it explicit that
they're about RemoteSettings.